### PR TITLE
Multithreaded friendly PVRTexture

### DIFF
--- a/PVRTexLibNET/PVRTexLibNET.cs
+++ b/PVRTexLibNET/PVRTexLibNET.cs
@@ -126,8 +126,10 @@ namespace PVRTexLibNET
         #endregion Interop
 
         private IntPtr _pPvrTexture = IntPtr.Zero;
+        private bool _isDisposed = false;
 
         public IntPtr PvrTexturePointer { get { return _pPvrTexture; } }
+        public bool IsDisposed { get {return _isDisposed; } }
         
         public PVRTexture(string filePath)
         {
@@ -146,47 +148,71 @@ namespace PVRTexLibNET
         {
             this._pPvrTexture = pPvrTexture;
         }
+
+        ~PVRTexture()
+        {
+            Dispose(false);
+        }
         
         public bool SaveTexture(string filePath)
         {
+            if (IsDisposed) throw new ObjectDisposedException("_pPvrTexture");
             return SaveTexture(_pPvrTexture, filePath);
         }
 
         public bool Resize(uint u32NewWidth, uint u32NewHeight, uint u32NewDepth, ResizeMode eResizeMode)
         {
+            if (IsDisposed) throw new ObjectDisposedException("_pPvrTexture");
             return Resize(_pPvrTexture, u32NewWidth, u32NewHeight, u32NewDepth, eResizeMode);
         }
         
         public bool GenerateMIPMaps(ResizeMode eFilterMode, uint uiMIPMapsToDo = int.MaxValue)
         {
+            if (IsDisposed) throw new ObjectDisposedException("_pPvrTexture");
             return GenerateMIPMaps(_pPvrTexture, eFilterMode, uiMIPMapsToDo);
         }
 
         public bool Transcode(PixelFormat ptFormat, VariableType eChannelType, ColourSpace eColourspace, CompressorQuality eQuality = CompressorQuality.PVRTCNormal, bool bDoDither = false)
         {
+            if (IsDisposed) throw new ObjectDisposedException("_pPvrTexture");
             return Transcode(_pPvrTexture, ptFormat, eChannelType, eColourspace, eQuality, bDoDither);
         }
 
         public uint GetTextureDataSize(int iMIPLevel = -1)
         {
+            if (IsDisposed) throw new ObjectDisposedException("_pPvrTexture");
             return GetTextureDataSize(_pPvrTexture, iMIPLevel);
         }
 
         public void GetTextureData<T>(T[] data, uint dataSize, uint uiMIPLevel = 0) where T : struct
         {
+            if (IsDisposed) throw new ObjectDisposedException("_pPvrTexture");
             var gcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             GetTextureData(_pPvrTexture, gcHandle.AddrOfPinnedObject(), dataSize, uiMIPLevel);
             gcHandle.Free();
         }
 
-        #region Implement IDisposable
+        #region Implement IDisposable & Dispose Pattern
         public void Dispose()
         {
-            if (_pPvrTexture != IntPtr.Zero)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (IsDisposed) return;
+
+            if (disposing)
             {
-                DestroyTexture(_pPvrTexture);
-                _pPvrTexture = IntPtr.Zero;
+                // release other disposable objects
+                
             }
+            // free resources
+            DestroyTexture(_pPvrTexture);
+            _pPvrTexture = IntPtr.Zero;
+            
+            _isDisposed = true;
         }
         #endregion
     }

--- a/PVRTexLibWrapper/PVRTexLibWrapper.cpp
+++ b/PVRTexLibWrapper/PVRTexLibWrapper.cpp
@@ -8,12 +8,9 @@
 
 using namespace pvrtexture;
 
-CPVRTexture* pvrTexture = NULL;
 
-extern void __cdecl CreateTexture(void* data, uint32 u32Width, uint32 u32Height, uint32 u32Depth, PixelType ptFormat, bool preMultiplied, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace)
+extern void* __cdecl CreateTexture(void* data, uint32 u32Width, uint32 u32Height, uint32 u32Depth, PixelType ptFormat, bool preMultiplied, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace)
 {
-    DestroyTexture();
-
     PVRTextureHeaderV3 pvrHeader;
     pvrHeader.u32Version = PVRTEX_CURR_IDENT;
     pvrHeader.u32Flags = preMultiplied ? PVRTEX3_PREMULTIPLIED : 0;
@@ -27,69 +24,78 @@ extern void __cdecl CreateTexture(void* data, uint32 u32Width, uint32 u32Height,
     pvrHeader.u32NumFaces = 1;
     pvrHeader.u32MIPMapCount = 1;
     pvrHeader.u32MetaDataSize = 0;
-    pvrTexture = new CPVRTexture(pvrHeader, data);
+	CPVRTexture* pvrTexture = new CPVRTexture(pvrHeader, data);
+
+	return pvrTexture;
 }
 
-extern void __cdecl CreateTextureFromFile(const char* filePath)
+extern void* __cdecl CreateTextureFromFile(const char* filePath)
 {
-    DestroyTexture();
-
-    pvrTexture = new CPVRTexture(filePath);
+	CPVRTexture* pvrTexture = new CPVRTexture(filePath);
+	
+	return pvrTexture;
 }
 
-extern bool __cdecl SaveTexture(const char* filePath)
+extern bool __cdecl SaveTexture(void* pPvrTexture, const char* filePath)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return false;
     return pvrTexture->saveFile(filePath);
 }
 
-extern void __cdecl DestroyTexture()
+extern void __cdecl DestroyTexture(void* pPvrTexture)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture != NULL)
     {
         delete pvrTexture;
-        pvrTexture = NULL;
     }
 }
 
-extern bool __cdecl Resize(uint32 u32NewWidth, uint32 u32NewHeight, uint32 u32NewDepth, EResizeMode eResizeMode)
+extern bool __cdecl Resize(void* pPvrTexture, uint32 u32NewWidth, uint32 u32NewHeight, uint32 u32NewDepth, EResizeMode eResizeMode)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return false;
     return pvrtexture::Resize(*pvrTexture, u32NewWidth, u32NewHeight, u32NewDepth, eResizeMode);
 }
 
-extern bool __cdecl PremultiplyAlpha()
+extern bool __cdecl PremultiplyAlpha(void* pPvrTexture)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return false;
     return pvrtexture::PreMultiplyAlpha(*pvrTexture);
 }
 
-extern bool __cdecl GenerateMIPMaps(EResizeMode eFilterMode, uint32 uiMIPMapsToDo)
+extern bool __cdecl GenerateMIPMaps(void* pPvrTexture, EResizeMode eFilterMode, uint32 uiMIPMapsToDo)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return false;
     return pvrtexture::GenerateMIPMaps(*pvrTexture, eFilterMode, uiMIPMapsToDo);
 }
 
-extern bool __cdecl Transcode(PixelType ptFormat, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace, ECompressorQuality eQuality, bool bDoDither)
+extern bool __cdecl Transcode(void* pPvrTexture, PixelType ptFormat, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace, ECompressorQuality eQuality, bool bDoDither)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return false;
     return pvrtexture::Transcode(*pvrTexture, ptFormat, eChannelType, eColourspace, eQuality, bDoDither);
 }
 
-extern uint32 __cdecl GetTextureDataSize(int32 iMIPLevel)
+extern uint32 __cdecl GetTextureDataSize(void* pPvrTexture, int32 iMIPLevel)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return 0;
     return pvrTexture->getDataSize(iMIPLevel);
 }
 
-extern void __cdecl GetTextureData(void* data, uint32 dataSize, uint32 uiMIPLevel)
+extern void __cdecl GetTextureData(void* pPvrTexture, void* data, uint32 dataSize, uint32 uiMIPLevel)
 {
+	CPVRTexture* pvrTexture = (CPVRTexture*)pPvrTexture;
     if (pvrTexture == NULL)
         return;
     memcpy(data, pvrTexture->getDataPtr(uiMIPLevel), dataSize);

--- a/PVRTexLibWrapper/PVRTexLibWrapper.h
+++ b/PVRTexLibWrapper/PVRTexLibWrapper.h
@@ -9,23 +9,23 @@
 using namespace pvrtexture;
 
 extern "C" {
-    __declspec(dllexport) void __cdecl CreateTexture(void* data, uint32 u32Width, uint32 u32Height, uint32 u32Depth, PixelType ptFormat, bool preMultiplied, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace);
+    __declspec(dllexport) void* __cdecl CreateTexture(void* data, uint32 u32Width, uint32 u32Height, uint32 u32Depth, PixelType ptFormat, bool preMultiplied, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace);
 
-    __declspec(dllexport) void __cdecl CreateTextureFromFile(const char* filePath);
+    __declspec(dllexport) void* __cdecl CreateTextureFromFile(const char* filePath);
 
-    __declspec(dllexport) bool __cdecl SaveTexture(const char* filePath);
+    __declspec(dllexport) bool __cdecl SaveTexture(void* pPvrTexture, const char* filePath);
 
-    __declspec(dllexport) void __cdecl DestroyTexture();
+    __declspec(dllexport) void __cdecl DestroyTexture(void* pPvrTexture);
 
-    __declspec(dllexport) bool __cdecl Resize(uint32 u32NewWidth, uint32 u32NewHeight, uint32 u32NewDepth, EResizeMode eResizeMode);
+    __declspec(dllexport) bool __cdecl Resize(void* pPvrTexture, uint32 u32NewWidth, uint32 u32NewHeight, uint32 u32NewDepth, EResizeMode eResizeMode);
 
-    __declspec(dllexport) bool __cdecl PremultiplyAlpha();
+    __declspec(dllexport) bool __cdecl PremultiplyAlpha(void* pPvrTexture);
 
-    __declspec(dllexport) bool __cdecl GenerateMIPMaps(EResizeMode eFilterMode, uint32 uiMIPMapsToDo = PVRTEX_ALLMIPLEVELS);
+    __declspec(dllexport) bool __cdecl GenerateMIPMaps(void* pPvrTexture, EResizeMode eFilterMode, uint32 uiMIPMapsToDo = PVRTEX_ALLMIPLEVELS);
 
-    __declspec(dllexport) bool __cdecl Transcode(PixelType ptFormat, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace, ECompressorQuality eQuality = ePVRTCNormal, bool bDoDither = false);
+    __declspec(dllexport) bool __cdecl Transcode(void* pPvrTexture, PixelType ptFormat, EPVRTVariableType eChannelType, EPVRTColourSpace eColourspace, ECompressorQuality eQuality = ePVRTCNormal, bool bDoDither = false);
 
-    __declspec(dllexport) uint32 __cdecl GetTextureDataSize(int32 iMIPLevel = PVRTEX_ALLMIPLEVELS);
+    __declspec(dllexport) uint32 __cdecl GetTextureDataSize(void* pPvrTexture, int32 iMIPLevel = PVRTEX_ALLMIPLEVELS);
 
-    __declspec(dllexport) void __cdecl GetTextureData(void* data, uint32 dataSize, uint32 uiMIPLevel = 0);
+    __declspec(dllexport) void __cdecl GetTextureData(void* pPvrTexture, void* data, uint32 dataSize, uint32 uiMIPLevel = 0);
 }


### PR DESCRIPTION
-Remove global CPVRTexture, all CPVRTexture functions accept a
CPVRTexture argument.
-Make PVRTexture non-static.
-Implement IDisposable.
